### PR TITLE
Use async fetching and data validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ dependencies = [
     "toml",
     "click",
     "requests",
+    "httpx>=0.27.2",
+    "pydantic>=2",
 ]
 
 [project.urls]

--- a/src/nomad_plugins/plugin_crawler.py
+++ b/src/nomad_plugins/plugin_crawler.py
@@ -637,9 +637,9 @@ def get_authentication_token(
         str: The authentication token if successfully retrieved, otherwise None.
     """
     try:
-        response = requests.get(
+        response = requests.post(
             f'{nomad_url}/auth/token',
-            params=dict(username=username, password=password),
+            data=dict(username=username, password=password),
             timeout=10,
         )
         token = response.json().get('access_token')

--- a/src/nomad_plugins/plugin_crawler.py
+++ b/src/nomad_plugins/plugin_crawler.py
@@ -378,7 +378,7 @@ async def get_toml_project(
     """
     Fetches and parses the `pyproject.toml` file from a given GitHub repository.
     Args:
-        search_result (GitHubSearchResultItem): The URL of the GitHub repository.
+        search_result (GitHubSearchResultItem): The search result from the GitHub code search.
         subdirectory (str): The subdirectory within the repository where the
                             `pyproject.toml` file is located.
         headers (dict): The headers to include in the request, typically containing


### PR DESCRIPTION
Closes #19 
Closes #18 
Closes #13 

Main changes:
1. Use pydantic models to validate and represent the data (it was helpful to know all of the fields which were available upfront, and the validation and model json dump are nice to haves)
2. Fetch all of the github search results concurrently. 
3. Fetch all of the plugin data concurrently based on the github search results collected upfront
4. Build the `plugin_dependencies` based on the plugin data fetched in step 3

Overall: 10s to finish crawling all of the plugin data with the above refactors compared to > 4 mins on main.  
