### PR TITLE
Extend schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,20 @@ Options:
   --help                 Show this message and exit.
 ```
 
+## Recent updates
+
+- Added `archived` support end-to-end in schema and crawler extraction. (Issue #25)
+- Added `owner_type` (`Organization`/`User`) to schema and crawler mapping. (Issue #26)
+- Added `docs_url` detection via GitHub Pages
+  (`https://<owner>.github.io/<repo>/`) and included it in crawler output.
+  (Issue #23)
+- Fixed `on_central` / `on_example_oasis` deployment detection:
+  - API-first via `/api/v1/info`
+  - fallback to `nomad-distro` `pyproject.toml` plugin list
+  (Issue #22)
+- Improved deployment matching robustness by normalizing package names before
+  comparison.
+
 
 ## Main contributors
 | Name | E-mail     |

--- a/README.md
+++ b/README.md
@@ -72,20 +72,6 @@ Options:
   --help                 Show this message and exit.
 ```
 
-## Recent updates
-
-- Added `archived` support end-to-end in schema and crawler extraction. (Issue #25)
-- Added `owner_type` (`Organization`/`User`) to schema and crawler mapping. (Issue #26)
-- Added `docs_url` detection via GitHub Pages
-  (`https://<owner>.github.io/<repo>/`) and included it in crawler output.
-  (Issue #23)
-- Fixed `on_central` / `on_example_oasis` deployment detection:
-  - API-first via `/api/v1/info`
-  - fallback to `nomad-distro` `pyproject.toml` plugin list
-  (Issue #22)
-- Improved deployment matching robustness by normalizing package names before
-  comparison.
-
 
 ## Main contributors
 | Name | E-mail     |

--- a/src/nomad_plugins/apps/__init__.py
+++ b/src/nomad_plugins/apps/__init__.py
@@ -48,6 +48,7 @@ plugin_app_entry_point = AppEntryPoint(
                 f'data.on_central#{schema}',
                 f'data.on_example_oasis#{schema}',
                 f'data.on_pypi#{schema}',
+                f'data.archived#{schema}',
                 f'data.stars#{schema}',
             ],
             options={
@@ -68,6 +69,9 @@ plugin_app_entry_point = AppEntryPoint(
                 ),
                 f'data.on_pypi#{schema}': Column(
                     label='On PyPI',
+                ),
+                f'data.archived#{schema}': Column(
+                    label='Archived',
                 ),
                 f'data.stars#{schema}': Column(
                     label='Stars',
@@ -129,6 +133,13 @@ plugin_app_entry_point = AppEntryPoint(
                 MenuItemTerms(
                     search_quantity=f'data.on_pypi#{schema}',
                     title='On PyPI',
+                    show_input=False,
+                    options=2,
+                    n_columns=2,
+                ),
+                MenuItemTerms(
+                    search_quantity=f'data.archived#{schema}',
+                    title='Archived',
                     show_input=False,
                     options=2,
                     n_columns=2,

--- a/src/nomad_plugins/apps/__init__.py
+++ b/src/nomad_plugins/apps/__init__.py
@@ -45,6 +45,7 @@ plugin_app_entry_point = AppEntryPoint(
                 f'data.name#{schema}',
                 f'data.owner#{schema}',
                 f'data.owner_type#{schema}',
+                f'data.docs_url#{schema}',
                 f'data.repository#{schema}',
                 f'data.on_central#{schema}',
                 f'data.on_example_oasis#{schema}',
@@ -61,6 +62,9 @@ plugin_app_entry_point = AppEntryPoint(
                 ),
                 f'data.owner_type#{schema}': Column(
                     label='Owner type',
+                ),
+                f'data.docs_url#{schema}': Column(
+                    label='Docs',
                 ),
                 f'data.repository#{schema}': Column(
                     label='Repository',

--- a/src/nomad_plugins/apps/__init__.py
+++ b/src/nomad_plugins/apps/__init__.py
@@ -44,6 +44,7 @@ plugin_app_entry_point = AppEntryPoint(
             selected=[
                 f'data.name#{schema}',
                 f'data.owner#{schema}',
+                f'data.owner_type#{schema}',
                 f'data.repository#{schema}',
                 f'data.on_central#{schema}',
                 f'data.on_example_oasis#{schema}',
@@ -57,6 +58,9 @@ plugin_app_entry_point = AppEntryPoint(
                 ),
                 f'data.owner#{schema}': Column(
                     label='Owner',
+                ),
+                f'data.owner_type#{schema}': Column(
+                    label='Owner type',
                 ),
                 f'data.repository#{schema}': Column(
                     label='Repository',
@@ -99,6 +103,13 @@ plugin_app_entry_point = AppEntryPoint(
                     title='Depends on',
                     show_input=True,
                     options=8,
+                ),
+                MenuItemTerms(
+                    search_quantity=f'data.owner_type#{schema}',
+                    title='Owner type',
+                    show_input=False,
+                    options=2,
+                    n_columns=2,
                 ),
                 MenuItemTerms(
                     search_quantity=f'data.plugin_entry_points.type#{schema}',

--- a/src/nomad_plugins/plugin_crawler.py
+++ b/src/nomad_plugins/plugin_crawler.py
@@ -38,7 +38,9 @@ def extract_dependency_name(dependency_string: str) -> str:
         The extracted dependency name, stripped of any extra information.
     """
     # Remove comments and markers (anything after # and ;)
-    dependency_string = dependency_string.split('#')[0].strip().split(';')[0].strip()
+    dependency_string = (
+        dependency_string.split('#', maxsplit=1)[0].strip().split(';')[0].strip()
+    )
 
     # Remove version specifiers (e.g., >=1.2.3, ==2.0) using regex
     dependency_string = re.sub(r'[<>=~!].*', '', dependency_string).strip()
@@ -364,7 +366,9 @@ class DeploymentInfoURLs(Enum):
 
 
 class DistroPyprojectURLs(Enum):
-    CENTRAL = 'https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-distro/-/raw/main/pyproject.toml'
+    CENTRAL = (
+        'https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-distro/-/raw/main/pyproject.toml'
+    )
     EXAMPLE = 'https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-distro/-/raw/test-oasis/pyproject.toml'
 
 
@@ -395,9 +399,7 @@ async def fetch_nomad_deployment_plugins_from_pyproject(pyproject_url: str) -> s
         return set()
 
     plugins = (
-        pyproject.get('project', {})
-        .get('optional-dependencies', {})
-        .get('plugins', [])
+        pyproject.get('project', {}).get('optional-dependencies', {}).get('plugins', [])
     )
     normalized = {normalize_package_name(dep) for dep in plugins}
     normalized = {name for name in normalized if name}
@@ -446,7 +448,9 @@ async def resolve_deployed_plugin_packages(
     if deployed_plugins:
         return deployed_plugins
 
-    deployed_plugins = await fetch_nomad_deployment_plugins_from_pyproject(pyproject_url)
+    deployed_plugins = await fetch_nomad_deployment_plugins_from_pyproject(
+        pyproject_url
+    )
     if deployed_plugins:
         return deployed_plugins
     return set()

--- a/src/nomad_plugins/plugin_crawler.py
+++ b/src/nomad_plugins/plugin_crawler.py
@@ -24,8 +24,6 @@ env_path = Path('.env')
 if env_path.exists():
     load_dotenv(env_path)
 
-DEBUG_DEPLOYMENT_MATCHING = os.getenv('PLUGIN_CRAWLER_DEBUG_MATCHING', '0') == '1'
-
 
 def extract_dependency_name(dependency_string: str) -> str:
     """Extracts the core dependency name from a dependency string,
@@ -389,15 +387,11 @@ async def fetch_nomad_deployment_plugins_from_pyproject(pyproject_url: str) -> s
     """
     response = await fetch_page_async(pyproject_url)
     if not response:
-        if DEBUG_DEPLOYMENT_MATCHING:
-            click.echo(f'[debug] Failed to fetch pyproject from {pyproject_url}')
         return set()
 
     try:
         pyproject = toml.loads(response.text)
     except toml.TomlDecodeError:
-        if DEBUG_DEPLOYMENT_MATCHING:
-            click.echo(f'[debug] Failed to parse TOML from {pyproject_url}')
         return set()
 
     plugins = (
@@ -407,11 +401,6 @@ async def fetch_nomad_deployment_plugins_from_pyproject(pyproject_url: str) -> s
     )
     normalized = {normalize_package_name(dep) for dep in plugins}
     normalized = {name for name in normalized if name}
-    if DEBUG_DEPLOYMENT_MATCHING:
-        click.echo(
-            f'[debug] Parsed {len(normalized)} plugin package names from {pyproject_url}'
-        )
-        click.echo(f'[debug] Sample pyproject plugin names: {sorted(normalized)[:10]}')
     return normalized
 
 
@@ -421,15 +410,11 @@ async def fetch_nomad_deployment_plugins_from_info(info_url: str) -> set[str]:
     """
     response = await fetch_page_async(info_url)
     if not response:
-        if DEBUG_DEPLOYMENT_MATCHING:
-            click.echo(f'[debug] Failed to fetch deployment info from {info_url}')
         return set()
 
     try:
         payload = response.json()
     except Exception:
-        if DEBUG_DEPLOYMENT_MATCHING:
-            click.echo(f'[debug] Failed to parse JSON from {info_url}')
         return set()
 
     plugin_packages = payload.get('plugin_packages', [])
@@ -446,12 +431,6 @@ async def fetch_nomad_deployment_plugins_from_info(info_url: str) -> set[str]:
     }
 
     result = {name for name in package_names.union(entry_point_packages) if name}
-    if DEBUG_DEPLOYMENT_MATCHING:
-        sample = sorted(result)[:10]
-        click.echo(
-            f'[debug] Parsed {len(result)} plugin package names from {info_url}'
-        )
-        click.echo(f'[debug] Sample deployed package names: {sample}')
     return result
 
 
@@ -715,14 +694,6 @@ async def find_plugins(
         info_url=DeploymentInfoURLs.CENTRAL.value,
         pyproject_url=DistroPyprojectURLs.CENTRAL.value,
     )
-    if DEBUG_DEPLOYMENT_MATCHING:
-        click.echo(
-            f'[debug] Central deployment packages resolved: {len(central_plugins)} entries'
-        )
-        click.echo(
-            f'[debug] Example oasis deployment packages resolved: '
-            f'{len(example_oasis_plugins)} entries'
-        )
 
     query = 'nomad.plugin in:file filename:pyproject.toml'
     params = {
@@ -756,19 +727,6 @@ async def find_plugins(
             if plugin:
                 plugins[plugin.name] = plugin
             bar.update(1)
-    if DEBUG_DEPLOYMENT_MATCHING:
-        on_central_count = sum(1 for plugin in plugins.values() if plugin.on_central)
-        on_example_count = sum(
-            1 for plugin in plugins.values() if plugin.on_example_oasis
-        )
-        click.echo(
-            f'[debug] Plugins matched on central: '
-            f'{on_central_count}/{len(plugins)}'
-        )
-        click.echo(
-            f'[debug] Plugins matched on example oasis: '
-            f'{on_example_count}/{len(plugins)}'
-        )
 
     data: list[PluginData] = []
 

--- a/src/nomad_plugins/plugin_crawler.py
+++ b/src/nomad_plugins/plugin_crawler.py
@@ -324,6 +324,7 @@ class Plugin(BaseModel):
     owner: str
     name: str
     description: str | None = None
+    archived: bool
     all_dependencies: set[str] = Field(
         set(), description='Placeholder field to store all dependencies', exclude=True
     )
@@ -484,6 +485,7 @@ async def get_plugin(
         name=name,
         all_dependencies=all_dependencies,
         description=project.description,
+        archived=repo_details.archived,
         authors=authors,
         maintainers=maintainers,
         on_central=on_central,

--- a/src/nomad_plugins/plugin_crawler.py
+++ b/src/nomad_plugins/plugin_crawler.py
@@ -24,6 +24,8 @@ env_path = Path('.env')
 if env_path.exists():
     load_dotenv(env_path)
 
+DEBUG_DEPLOYMENT_MATCHING = os.getenv('PLUGIN_CRAWLER_DEBUG_MATCHING', '0') == '1'
+
 
 def extract_dependency_name(dependency_string: str) -> str:
     """Extracts the core dependency name from a dependency string,
@@ -50,6 +52,21 @@ def extract_dependency_name(dependency_string: str) -> str:
     dependency_string = re.sub(r'\s*;\s*extra.*', '', dependency_string).strip()
 
     return dependency_string
+
+
+def normalize_package_name(package_name: str) -> str:
+    """
+    Normalize package names for robust comparisons.
+
+    Uses a lightweight PEP 503-compatible normalization by lower-casing and
+    replacing runs of ``-_.`` with ``-``. Extras and non-package requirement
+    directives are ignored.
+    """
+    package_name = extract_dependency_name(package_name.strip())
+    if not package_name or package_name.startswith('-') or ' ' in package_name:
+        return ''
+    package_name = package_name.split('[', maxsplit=1)[0]
+    return re.sub(r'[-_.]+', '-', package_name).lower()
 
 
 class GitHubOwner(BaseModel):
@@ -351,6 +368,16 @@ class OasisURLs(Enum):
     EXAMPLE = 'https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-distro/-/raw/test-oasis/requirements.txt'
 
 
+class DeploymentInfoURLs(Enum):
+    CENTRAL = 'https://nomad-lab.eu/prod/v1/api/v1/info'
+    EXAMPLE = 'https://nomad-lab.eu/prod/v1/oasis/api/v1/info'
+
+
+class DistroPyprojectURLs(Enum):
+    CENTRAL = 'https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-distro/-/raw/main/pyproject.toml'
+    EXAMPLE = 'https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-distro/-/raw/test-oasis/pyproject.toml'
+
+
 # GitHub Code Search API URL
 GITHUB_CODE_API = 'https://api.github.com/search/code'
 GITHUB_REPO_API = 'https://api.github.com/repos'
@@ -376,13 +403,115 @@ async def fetch_nomad_deployment_requirements(
     """
     response = await fetch_page_async(requirements_url)
     if response:
-        return set(
-            [
-                # the first two lines are preamble by uv
-                extract_dependency_name(line)
-                for line in response.text.splitlines()[2:]
-            ]
+        requirements = {
+            normalize_package_name(line) for line in response.text.splitlines()
+        }
+        requirements = {dep for dep in requirements if dep}
+        if DEBUG_DEPLOYMENT_MATCHING:
+            sample = sorted(requirements)[:10]
+            click.echo(
+                f'[debug] Parsed {len(requirements)} dependencies from {requirements_url}'
+            )
+            click.echo(f'[debug] Sample dependencies: {sample}')
+        return requirements
+    if DEBUG_DEPLOYMENT_MATCHING:
+        click.echo(f'[debug] Failed to fetch requirements from {requirements_url}')
+    return set()
+
+
+async def fetch_nomad_deployment_plugins_from_pyproject(pyproject_url: str) -> set[str]:
+    """
+    Fetch deployed plugin package names from nomad-distro `pyproject.toml`.
+    """
+    response = await fetch_page_async(pyproject_url)
+    if not response:
+        if DEBUG_DEPLOYMENT_MATCHING:
+            click.echo(f'[debug] Failed to fetch pyproject from {pyproject_url}')
+        return set()
+
+    try:
+        pyproject = toml.loads(response.text)
+    except toml.TomlDecodeError:
+        if DEBUG_DEPLOYMENT_MATCHING:
+            click.echo(f'[debug] Failed to parse TOML from {pyproject_url}')
+        return set()
+
+    plugins = (
+        pyproject.get('project', {})
+        .get('optional-dependencies', {})
+        .get('plugins', [])
+    )
+    normalized = {normalize_package_name(dep) for dep in plugins}
+    normalized = {name for name in normalized if name}
+    if DEBUG_DEPLOYMENT_MATCHING:
+        click.echo(
+            f'[debug] Parsed {len(normalized)} plugin package names from {pyproject_url}'
         )
+        click.echo(f'[debug] Sample pyproject plugin names: {sorted(normalized)[:10]}')
+    return normalized
+
+
+async def fetch_nomad_deployment_plugins_from_info(info_url: str) -> set[str]:
+    """
+    Fetch deployed plugin package names from NOMAD ``/api/v1/info``.
+    """
+    response = await fetch_page_async(info_url)
+    if not response:
+        if DEBUG_DEPLOYMENT_MATCHING:
+            click.echo(f'[debug] Failed to fetch deployment info from {info_url}')
+        return set()
+
+    try:
+        payload = response.json()
+    except Exception:
+        if DEBUG_DEPLOYMENT_MATCHING:
+            click.echo(f'[debug] Failed to parse JSON from {info_url}')
+        return set()
+
+    plugin_packages = payload.get('plugin_packages', [])
+    package_names = {
+        normalize_package_name(plugin_package.get('name', ''))
+        for plugin_package in plugin_packages
+    }
+
+    # Fallback signal in case package list is absent: infer names from entry points.
+    plugin_entry_points = payload.get('plugin_entry_points', [])
+    entry_point_packages = {
+        normalize_package_name(entry_point.get('python_package', ''))
+        for entry_point in plugin_entry_points
+    }
+
+    result = {name for name in package_names.union(entry_point_packages) if name}
+    if DEBUG_DEPLOYMENT_MATCHING:
+        sample = sorted(result)[:10]
+        click.echo(
+            f'[debug] Parsed {len(result)} plugin package names from {info_url}'
+        )
+        click.echo(f'[debug] Sample deployed package names: {sample}')
+    return result
+
+
+async def resolve_deployed_plugin_packages(
+    *,
+    info_url: str,
+    pyproject_url: str,
+    legacy_requirements_url: str | None = None,
+) -> set[str]:
+    """
+    Resolve deployed plugin packages using API-first strategy with pyproject fallback.
+    """
+    deployed_plugins = await fetch_nomad_deployment_plugins_from_info(info_url)
+    if deployed_plugins:
+        return deployed_plugins
+
+    deployed_plugins = await fetch_nomad_deployment_plugins_from_pyproject(pyproject_url)
+    if deployed_plugins:
+        return deployed_plugins
+
+    if DEBUG_DEPLOYMENT_MATCHING:
+        click.echo('[debug] Falling back to legacy requirements-based matching')
+    if legacy_requirements_url:
+        return await fetch_nomad_deployment_requirements(legacy_requirements_url)
     return set()
 
 
@@ -500,11 +629,12 @@ async def get_plugin(
         return None
     repo_details = GitHubRepositoryDetailed.model_validate(repo_contents.json())
     name = project.name
+    normalized_name = normalize_package_name(name)
     on_pypi_task = package_exists_on_pypi(name)
     docs_url_task = check_github_pages_exists(str(repo_info.html_url))
     on_pypi, docs_url = await asyncio.gather(on_pypi_task, docs_url_task)
-    on_central = name in central_plugins
-    on_example_oasis = name in example_oasis_plugins
+    on_central = normalized_name in central_plugins
+    on_example_oasis = normalized_name in example_oasis_plugins
     plugin_entry_points = (
         project.entry_points.nomad_plugin if project.entry_points else []
     )
@@ -619,10 +749,24 @@ async def find_plugins(
     Args:
         token (str): GitHub personal access token for authentication.
     """
-    example_oasis_plugins = await fetch_nomad_deployment_requirements(
-        OasisURLs.EXAMPLE.value
+    example_oasis_plugins = await resolve_deployed_plugin_packages(
+        info_url=DeploymentInfoURLs.EXAMPLE.value,
+        pyproject_url=DistroPyprojectURLs.EXAMPLE.value,
+        legacy_requirements_url=OasisURLs.EXAMPLE.value,
     )
-    central_plugins = await fetch_nomad_deployment_requirements(OasisURLs.CENTRAL.value)
+    central_plugins = await resolve_deployed_plugin_packages(
+        info_url=DeploymentInfoURLs.CENTRAL.value,
+        pyproject_url=DistroPyprojectURLs.CENTRAL.value,
+        legacy_requirements_url=OasisURLs.CENTRAL.value,
+    )
+    if DEBUG_DEPLOYMENT_MATCHING:
+        click.echo(
+            f'[debug] Central requirements parsed: {len(central_plugins)} entries'
+        )
+        click.echo(
+            f'[debug] Example oasis requirements parsed: '
+            f'{len(example_oasis_plugins)} entries'
+        )
 
     query = 'nomad.plugin in:file filename:pyproject.toml'
     params = {
@@ -656,6 +800,19 @@ async def find_plugins(
             if plugin:
                 plugins[plugin.name] = plugin
             bar.update(1)
+    if DEBUG_DEPLOYMENT_MATCHING:
+        on_central_count = sum(1 for plugin in plugins.values() if plugin.on_central)
+        on_example_count = sum(
+            1 for plugin in plugins.values() if plugin.on_example_oasis
+        )
+        click.echo(
+            f'[debug] Plugins matched on central: '
+            f'{on_central_count}/{len(plugins)}'
+        )
+        click.echo(
+            f'[debug] Plugins matched on example oasis: '
+            f'{on_example_count}/{len(plugins)}'
+        )
 
     data: list[PluginData] = []
 

--- a/src/nomad_plugins/plugin_crawler.py
+++ b/src/nomad_plugins/plugin_crawler.py
@@ -323,6 +323,7 @@ class Plugin(BaseModel):
     last_updated: str
     owner: str
     owner_type: str | None = None
+    docs_url: HttpUrl | None = None
     name: str
     description: str | None = None
     archived: bool
@@ -442,6 +443,37 @@ async def package_exists_on_pypi(package_name: str) -> bool:
             return False
 
 
+async def check_github_pages_exists(repository_url: str) -> str | None:
+    """
+    Check whether a repository has a standard GitHub Pages site.
+
+    For repositories like ``https://github.com/<owner>/<repo>`` this checks
+    ``https://<owner>.github.io/<repo>/``.
+    """
+    if 'github.com/' not in repository_url:
+        return None
+
+    try:
+        owner_repo = repository_url.rstrip('/').split('github.com/', maxsplit=1)[1]
+        parts = owner_repo.split('/')
+        if len(parts) < 2:
+            return None
+        owner = parts[0]
+        repo = parts[1]
+    except (IndexError, ValueError):
+        return None
+
+    docs_url = f'https://{owner.lower()}.github.io/{repo}/'
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.head(docs_url, follow_redirects=True)
+            if response.status_code in (200, 301, 302):  # noqa: PLR2004
+                return docs_url
+        except httpx.RequestError:
+            return None
+    return None
+
+
 async def get_plugin(
     *,
     item: GitHubSearchResultItem,
@@ -468,7 +500,9 @@ async def get_plugin(
         return None
     repo_details = GitHubRepositoryDetailed.model_validate(repo_contents.json())
     name = project.name
-    on_pypi = await package_exists_on_pypi(name)
+    on_pypi_task = package_exists_on_pypi(name)
+    docs_url_task = check_github_pages_exists(str(repo_info.html_url))
+    on_pypi, docs_url = await asyncio.gather(on_pypi_task, docs_url_task)
     on_central = name in central_plugins
     on_example_oasis = name in example_oasis_plugins
     plugin_entry_points = (
@@ -486,6 +520,7 @@ async def get_plugin(
         last_updated=repo_details.updated_at,
         owner=repo_info.owner.login,
         owner_type=owner_type,
+        docs_url=docs_url,
         name=name,
         all_dependencies=all_dependencies,
         description=project.description,

--- a/src/nomad_plugins/plugin_crawler.py
+++ b/src/nomad_plugins/plugin_crawler.py
@@ -360,14 +360,6 @@ class PluginData(BaseModel):
     data: Plugin
 
 
-class OasisURLs(Enum):
-    CENTRAL = (
-        'https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-distro/-/raw/main/requirements.txt'
-    )
-
-    EXAMPLE = 'https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-distro/-/raw/test-oasis/requirements.txt'
-
-
 class DeploymentInfoURLs(Enum):
     CENTRAL = 'https://nomad-lab.eu/prod/v1/api/v1/info'
     EXAMPLE = 'https://nomad-lab.eu/prod/v1/oasis/api/v1/info'
@@ -389,34 +381,6 @@ EXCLUDED_REPOS = {
     'FAIRmat-NFDI/cookiecutter-nomad-plugin',
     'FAIRmat-NFDI/pynxtools-plugin-template',
 }
-
-
-async def fetch_nomad_deployment_requirements(
-    requirements_url: str,
-) -> set[str]:
-    """
-    Fetches and parses a `requirements.txt` file from a given URL.
-    Args:
-        requirements_url (str): The URL of the `requirements.txt` file.
-    Returns:
-        set: set of dependencies
-    """
-    response = await fetch_page_async(requirements_url)
-    if response:
-        requirements = {
-            normalize_package_name(line) for line in response.text.splitlines()
-        }
-        requirements = {dep for dep in requirements if dep}
-        if DEBUG_DEPLOYMENT_MATCHING:
-            sample = sorted(requirements)[:10]
-            click.echo(
-                f'[debug] Parsed {len(requirements)} dependencies from {requirements_url}'
-            )
-            click.echo(f'[debug] Sample dependencies: {sample}')
-        return requirements
-    if DEBUG_DEPLOYMENT_MATCHING:
-        click.echo(f'[debug] Failed to fetch requirements from {requirements_url}')
-    return set()
 
 
 async def fetch_nomad_deployment_plugins_from_pyproject(pyproject_url: str) -> set[str]:
@@ -495,7 +459,6 @@ async def resolve_deployed_plugin_packages(
     *,
     info_url: str,
     pyproject_url: str,
-    legacy_requirements_url: str | None = None,
 ) -> set[str]:
     """
     Resolve deployed plugin packages using API-first strategy with pyproject fallback.
@@ -507,11 +470,6 @@ async def resolve_deployed_plugin_packages(
     deployed_plugins = await fetch_nomad_deployment_plugins_from_pyproject(pyproject_url)
     if deployed_plugins:
         return deployed_plugins
-
-    if DEBUG_DEPLOYMENT_MATCHING:
-        click.echo('[debug] Falling back to legacy requirements-based matching')
-    if legacy_requirements_url:
-        return await fetch_nomad_deployment_requirements(legacy_requirements_url)
     return set()
 
 
@@ -752,19 +710,17 @@ async def find_plugins(
     example_oasis_plugins = await resolve_deployed_plugin_packages(
         info_url=DeploymentInfoURLs.EXAMPLE.value,
         pyproject_url=DistroPyprojectURLs.EXAMPLE.value,
-        legacy_requirements_url=OasisURLs.EXAMPLE.value,
     )
     central_plugins = await resolve_deployed_plugin_packages(
         info_url=DeploymentInfoURLs.CENTRAL.value,
         pyproject_url=DistroPyprojectURLs.CENTRAL.value,
-        legacy_requirements_url=OasisURLs.CENTRAL.value,
     )
     if DEBUG_DEPLOYMENT_MATCHING:
         click.echo(
-            f'[debug] Central requirements parsed: {len(central_plugins)} entries'
+            f'[debug] Central deployment packages resolved: {len(central_plugins)} entries'
         )
         click.echo(
-            f'[debug] Example oasis requirements parsed: '
+            f'[debug] Example oasis deployment packages resolved: '
             f'{len(example_oasis_plugins)} entries'
         )
 

--- a/src/nomad_plugins/plugin_crawler.py
+++ b/src/nomad_plugins/plugin_crawler.py
@@ -24,6 +24,8 @@ env_path = Path('.env')
 if env_path.exists():
     load_dotenv(env_path)
 
+GITHUB_OWNER_REPO_PARTS = 2
+
 
 def extract_dependency_name(dependency_string: str) -> str:
     """Extracts the core dependency name from a dependency string,
@@ -526,7 +528,7 @@ async def check_github_pages_exists(repository_url: str) -> str | None:
     try:
         owner_repo = repository_url.rstrip('/').split('github.com/', maxsplit=1)[1]
         parts = owner_repo.split('/')
-        if len(parts) < 2:
+        if len(parts) < GITHUB_OWNER_REPO_PARTS:
             return None
         owner = parts[0]
         repo = parts[1]

--- a/src/nomad_plugins/plugin_crawler.py
+++ b/src/nomad_plugins/plugin_crawler.py
@@ -322,6 +322,7 @@ class Plugin(BaseModel):
     created: str
     last_updated: str
     owner: str
+    owner_type: str | None = None
     name: str
     description: str | None = None
     archived: bool
@@ -476,12 +477,15 @@ async def get_plugin(
     authors = project.authors or []
     maintainers = project.maintainers or []
     all_dependencies = project.all_dependencies or set()
+    owner_type_raw = getattr(repo_info.owner, 'type', None)
+    owner_type = owner_type_raw if owner_type_raw in {'Organization', 'User'} else None
     plugin = Plugin(
         repository=repo_info.html_url,
         stars=repo_details.stargazers_count,
         created=repo_details.created_at,
         last_updated=repo_details.updated_at,
         owner=repo_info.owner.login,
+        owner_type=owner_type,
         name=name,
         all_dependencies=all_dependencies,
         description=project.description,

--- a/src/nomad_plugins/schema_packages/plugin.py
+++ b/src/nomad_plugins/schema_packages/plugin.py
@@ -75,6 +75,9 @@ class Plugin(Schema):
     owner = Quantity(
         type=str,
     )
+    owner_type = Quantity(
+        type=MEnum('Organization', 'User'),
+    )
     on_pypi = Quantity(
         type=bool,
     )

--- a/src/nomad_plugins/schema_packages/plugin.py
+++ b/src/nomad_plugins/schema_packages/plugin.py
@@ -78,6 +78,9 @@ class Plugin(Schema):
     on_pypi = Quantity(
         type=bool,
     )
+    archived = Quantity(
+        type=bool,
+    )
     on_central = Quantity(
         type=bool,
     )

--- a/src/nomad_plugins/schema_packages/plugin.py
+++ b/src/nomad_plugins/schema_packages/plugin.py
@@ -78,6 +78,9 @@ class Plugin(Schema):
     owner_type = Quantity(
         type=MEnum('Organization', 'User'),
     )
+    docs_url = Quantity(
+        type=str,
+    )
     on_pypi = Quantity(
         type=bool,
     )

--- a/tests/apps/test_app.py
+++ b/tests/apps/test_app.py
@@ -9,7 +9,16 @@ def test_importing_app():
         for column in plugin_app_entry_point.app.columns
     )
     assert any(
+        column.search_quantity == f'data.owner_type#{schema}'
+        for column in plugin_app_entry_point.app.columns
+    )
+    assert any(
         item.title == 'Archived'
         and item.search_quantity == f'data.archived#{schema}'
+        for item in plugin_app_entry_point.app.menu.items
+    )
+    assert any(
+        item.title == 'Owner type'
+        and item.search_quantity == f'data.owner_type#{schema}'
         for item in plugin_app_entry_point.app.menu.items
     )

--- a/tests/apps/test_app.py
+++ b/tests/apps/test_app.py
@@ -3,3 +3,13 @@ def test_importing_app():
     from nomad_plugins.apps import plugin_app_entry_point
 
     assert plugin_app_entry_point.app.label == 'NOMAD plugins'
+    schema = 'nomad_plugins.schema_packages.plugin.Plugin'
+    assert any(
+        column.search_quantity == f'data.archived#{schema}'
+        for column in plugin_app_entry_point.app.columns
+    )
+    assert any(
+        item.title == 'Archived'
+        and item.search_quantity == f'data.archived#{schema}'
+        for item in plugin_app_entry_point.app.menu.items
+    )

--- a/tests/apps/test_app.py
+++ b/tests/apps/test_app.py
@@ -13,6 +13,10 @@ def test_importing_app():
         for column in plugin_app_entry_point.app.columns
     )
     assert any(
+        column.search_quantity == f'data.docs_url#{schema}'
+        for column in plugin_app_entry_point.app.columns
+    )
+    assert any(
         item.title == 'Archived'
         and item.search_quantity == f'data.archived#{schema}'
         for item in plugin_app_entry_point.app.menu.items

--- a/tests/apps/test_app.py
+++ b/tests/apps/test_app.py
@@ -17,8 +17,7 @@ def test_importing_app():
         for column in plugin_app_entry_point.app.columns
     )
     assert any(
-        item.title == 'Archived'
-        and item.search_quantity == f'data.archived#{schema}'
+        item.title == 'Archived' and item.search_quantity == f'data.archived#{schema}'
         for item in plugin_app_entry_point.app.menu.items
     )
     assert any(

--- a/tests/data/test.archive.yaml
+++ b/tests/data/test.archive.yaml
@@ -2,5 +2,6 @@ data:
   m_def: nomad_plugins.schema_packages.plugin.Plugin
   repository: https://github.com/FAIRmat-NFDI/nomad-material-processing
   on_pypi: True
+  archived: False
   name: nomad-material-processing
   description: A plugin for NOMAD containing base sections for material processing.

--- a/tests/data/test.archive.yaml
+++ b/tests/data/test.archive.yaml
@@ -3,6 +3,7 @@ data:
   repository: https://github.com/FAIRmat-NFDI/nomad-material-processing
   owner: FAIRmat-NFDI
   owner_type: Organization
+  docs_url: https://fairmat-nfdi.github.io/nomad-material-processing/
   on_pypi: True
   archived: False
   name: nomad-material-processing

--- a/tests/data/test.archive.yaml
+++ b/tests/data/test.archive.yaml
@@ -1,6 +1,8 @@
 data:
   m_def: nomad_plugins.schema_packages.plugin.Plugin
   repository: https://github.com/FAIRmat-NFDI/nomad-material-processing
+  owner: FAIRmat-NFDI
+  owner_type: Organization
   on_pypi: True
   archived: False
   name: nomad-material-processing

--- a/tests/schema_packages/test_plugin.py
+++ b/tests/schema_packages/test_plugin.py
@@ -16,4 +16,8 @@ def test_schema_package():
         'A plugin for NOMAD containing base sections for material processing.'
     )
     assert entry_archive.data.owner_type == 'Organization'
+    assert (
+        entry_archive.data.docs_url
+        == 'https://fairmat-nfdi.github.io/nomad-material-processing/'
+    )
     assert entry_archive.data.archived is False

--- a/tests/schema_packages/test_plugin.py
+++ b/tests/schema_packages/test_plugin.py
@@ -15,3 +15,4 @@ def test_schema_package():
     assert entry_archive.metadata.comment == (
         'A plugin for NOMAD containing base sections for material processing.'
     )
+    assert entry_archive.data.archived is False

--- a/tests/schema_packages/test_plugin.py
+++ b/tests/schema_packages/test_plugin.py
@@ -15,4 +15,5 @@ def test_schema_package():
     assert entry_archive.metadata.comment == (
         'A plugin for NOMAD containing base sections for material processing.'
     )
+    assert entry_archive.data.owner_type == 'Organization'
     assert entry_archive.data.archived is False

--- a/tests/test_plugin_crawler.py
+++ b/tests/test_plugin_crawler.py
@@ -1,0 +1,63 @@
+import asyncio
+from types import SimpleNamespace
+
+from nomad_plugins import plugin_crawler
+
+
+def test_get_plugin_maps_archived_fields(monkeypatch):
+    async def fake_fetch_page_async(url, *, headers=None, params=None):
+        class FakeResponse:
+            def json(self):
+                return {}
+
+        return FakeResponse()
+
+    async def fake_get_toml_project(search_result):
+        return SimpleNamespace(
+            name='test-plugin',
+            entry_points=None,
+            authors=[],
+            maintainers=[],
+            all_dependencies=set(),
+            description='test description',
+        )
+
+    async def fake_package_exists_on_pypi(package_name):
+        return True
+
+    def fake_model_validate(_value):
+        return SimpleNamespace(
+            stargazers_count=42,
+            created_at='2024-01-01T00:00:00Z',
+            updated_at='2025-01-01T00:00:00Z',
+            archived=True,
+        )
+
+    monkeypatch.setattr(plugin_crawler, 'fetch_page_async', fake_fetch_page_async)
+    monkeypatch.setattr(plugin_crawler, 'get_toml_project', fake_get_toml_project)
+    monkeypatch.setattr(
+        plugin_crawler, 'package_exists_on_pypi', fake_package_exists_on_pypi
+    )
+    monkeypatch.setattr(
+        plugin_crawler.GitHubRepositoryDetailed, 'model_validate', fake_model_validate
+    )
+
+    item = SimpleNamespace(
+        repository=SimpleNamespace(
+            url='https://api.github.com/repos/example/test-plugin',
+            html_url='https://github.com/example/test-plugin',
+            owner=SimpleNamespace(login='example'),
+        )
+    )
+
+    plugin = asyncio.run(
+        plugin_crawler.get_plugin(
+            item=item,
+            headers={},
+            central_plugins={'test-plugin'},
+            example_oasis_plugins=set(),
+        )
+    )
+
+    assert plugin is not None
+    assert plugin.archived is True

--- a/tests/test_plugin_crawler.py
+++ b/tests/test_plugin_crawler.py
@@ -198,7 +198,9 @@ def test_resolve_deployed_plugin_packages_falls_back_to_pyproject(monkeypatch):
     assert resolved == {'nomad-parser-plugins-atomistic'}
 
 
-def test_resolve_deployed_plugin_packages_returns_empty_when_both_sources_fail(monkeypatch):
+def test_resolve_deployed_plugin_packages_returns_empty_when_both_sources_fail(
+    monkeypatch,
+):
     async def fake_fetch_nomad_deployment_plugins_from_info(info_url):
         return set()
 

--- a/tests/test_plugin_crawler.py
+++ b/tests/test_plugin_crawler.py
@@ -142,3 +142,124 @@ def test_check_github_pages_exists_non_github_url():
         plugin_crawler.check_github_pages_exists('https://gitlab.com/example/repo')
     )
     assert docs_url is None
+
+
+def test_resolve_deployed_plugin_packages_prefers_info_endpoint(monkeypatch):
+    async def fake_fetch_nomad_deployment_plugins_from_info(info_url):
+        return {'nomad-parser-plugins-workflow'}
+
+    async def fake_fetch_nomad_deployment_requirements(requirements_url):
+        return {'nomad-parser-plugins-atomistic'}
+
+    monkeypatch.setattr(
+        plugin_crawler,
+        'fetch_nomad_deployment_plugins_from_info',
+        fake_fetch_nomad_deployment_plugins_from_info,
+    )
+    monkeypatch.setattr(
+        plugin_crawler,
+        'fetch_nomad_deployment_plugins_from_pyproject',
+        fake_fetch_nomad_deployment_requirements,
+    )
+
+    resolved = asyncio.run(
+        plugin_crawler.resolve_deployed_plugin_packages(
+            info_url='https://nomad-lab.eu/prod/v1/api/v1/info',
+            pyproject_url='https://gitlab.example/pyproject.toml',
+            legacy_requirements_url='https://gitlab.example/requirements.txt',
+        )
+    )
+    assert resolved == {'nomad-parser-plugins-workflow'}
+
+
+def test_resolve_deployed_plugin_packages_falls_back_to_pyproject(monkeypatch):
+    async def fake_fetch_nomad_deployment_plugins_from_info(info_url):
+        return set()
+
+    async def fake_fetch_nomad_deployment_plugins_from_pyproject(pyproject_url):
+        return {'nomad-parser-plugins-atomistic'}
+
+    monkeypatch.setattr(
+        plugin_crawler,
+        'fetch_nomad_deployment_plugins_from_info',
+        fake_fetch_nomad_deployment_plugins_from_info,
+    )
+    monkeypatch.setattr(
+        plugin_crawler,
+        'fetch_nomad_deployment_plugins_from_pyproject',
+        fake_fetch_nomad_deployment_plugins_from_pyproject,
+    )
+
+    resolved = asyncio.run(
+        plugin_crawler.resolve_deployed_plugin_packages(
+            info_url='https://nomad-lab.eu/prod/v1/api/v1/info',
+            pyproject_url='https://gitlab.example/pyproject.toml',
+            legacy_requirements_url='https://gitlab.example/requirements.txt',
+        )
+    )
+    assert resolved == {'nomad-parser-plugins-atomistic'}
+
+
+def test_resolve_deployed_plugin_packages_falls_back_to_legacy_requirements(monkeypatch):
+    async def fake_fetch_nomad_deployment_plugins_from_info(info_url):
+        return set()
+
+    async def fake_fetch_nomad_deployment_plugins_from_pyproject(pyproject_url):
+        return set()
+
+    async def fake_fetch_nomad_deployment_requirements(requirements_url):
+        return {'nomad-parser-plugins-workflow'}
+
+    monkeypatch.setattr(
+        plugin_crawler,
+        'fetch_nomad_deployment_plugins_from_info',
+        fake_fetch_nomad_deployment_plugins_from_info,
+    )
+    monkeypatch.setattr(
+        plugin_crawler,
+        'fetch_nomad_deployment_plugins_from_pyproject',
+        fake_fetch_nomad_deployment_plugins_from_pyproject,
+    )
+    monkeypatch.setattr(
+        plugin_crawler,
+        'fetch_nomad_deployment_requirements',
+        fake_fetch_nomad_deployment_requirements,
+    )
+
+    resolved = asyncio.run(
+        plugin_crawler.resolve_deployed_plugin_packages(
+            info_url='https://nomad-lab.eu/prod/v1/api/v1/info',
+            pyproject_url='https://gitlab.example/pyproject.toml',
+            legacy_requirements_url='https://gitlab.example/requirements.txt',
+        )
+    )
+    assert resolved == {'nomad-parser-plugins-workflow'}
+
+
+def test_fetch_nomad_deployment_plugins_from_pyproject(monkeypatch):
+    pyproject_toml = """
+[project]
+name = "nomad-distribution"
+[project.optional-dependencies]
+plugins = [
+  "nomad-plugin-gui>=1.0.0",
+  "nomad-porous-materials @ git+https://github.com/FAIRmat-NFDI/nomad-porous-materials.git@abc",
+  "pynxtools[convert]==0.9.1",
+]
+"""
+
+    async def fake_fetch_page_async(url, *, headers=None, params=None):
+        class FakeResponse:
+            text = pyproject_toml
+
+        return FakeResponse()
+
+    monkeypatch.setattr(plugin_crawler, 'fetch_page_async', fake_fetch_page_async)
+    parsed = asyncio.run(
+        plugin_crawler.fetch_nomad_deployment_plugins_from_pyproject(
+            'https://gitlab.example/pyproject.toml'
+        )
+    )
+    assert 'nomad-plugin-gui' in parsed
+    assert 'nomad-porous-materials' in parsed
+    assert 'pynxtools' in parsed

--- a/tests/test_plugin_crawler.py
+++ b/tests/test_plugin_crawler.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 from nomad_plugins import plugin_crawler
 
 
-def test_get_plugin_maps_archived_fields(monkeypatch):
+def test_get_plugin_maps_archived_and_owner_type_fields(monkeypatch):
     async def fake_fetch_page_async(url, *, headers=None, params=None):
         class FakeResponse:
             def json(self):
@@ -46,7 +46,7 @@ def test_get_plugin_maps_archived_fields(monkeypatch):
         repository=SimpleNamespace(
             url='https://api.github.com/repos/example/test-plugin',
             html_url='https://github.com/example/test-plugin',
-            owner=SimpleNamespace(login='example'),
+            owner=SimpleNamespace(login='example', type='Bot'),
         )
     )
 
@@ -61,3 +61,63 @@ def test_get_plugin_maps_archived_fields(monkeypatch):
 
     assert plugin is not None
     assert plugin.archived is True
+    assert plugin.owner_type is None
+
+
+def test_get_plugin_maps_owner_type_organization(monkeypatch):
+    async def fake_fetch_page_async(url, *, headers=None, params=None):
+        class FakeResponse:
+            def json(self):
+                return {}
+
+        return FakeResponse()
+
+    async def fake_get_toml_project(search_result):
+        return SimpleNamespace(
+            name='test-plugin',
+            entry_points=None,
+            authors=[],
+            maintainers=[],
+            all_dependencies=set(),
+            description='test description',
+        )
+
+    async def fake_package_exists_on_pypi(package_name):
+        return True
+
+    def fake_model_validate(_value):
+        return SimpleNamespace(
+            stargazers_count=42,
+            created_at='2024-01-01T00:00:00Z',
+            updated_at='2025-01-01T00:00:00Z',
+            archived=True,
+        )
+
+    monkeypatch.setattr(plugin_crawler, 'fetch_page_async', fake_fetch_page_async)
+    monkeypatch.setattr(plugin_crawler, 'get_toml_project', fake_get_toml_project)
+    monkeypatch.setattr(
+        plugin_crawler, 'package_exists_on_pypi', fake_package_exists_on_pypi
+    )
+    monkeypatch.setattr(
+        plugin_crawler.GitHubRepositoryDetailed, 'model_validate', fake_model_validate
+    )
+
+    item = SimpleNamespace(
+        repository=SimpleNamespace(
+            url='https://api.github.com/repos/example/test-plugin',
+            html_url='https://github.com/example/test-plugin',
+            owner=SimpleNamespace(login='example', type='Organization'),
+        )
+    )
+
+    plugin = asyncio.run(
+        plugin_crawler.get_plugin(
+            item=item,
+            headers={},
+            central_plugins={'test-plugin'},
+            example_oasis_plugins=set(),
+        )
+    )
+
+    assert plugin is not None
+    assert plugin.owner_type == 'Organization'

--- a/tests/test_plugin_crawler.py
+++ b/tests/test_plugin_crawler.py
@@ -148,7 +148,7 @@ def test_resolve_deployed_plugin_packages_prefers_info_endpoint(monkeypatch):
     async def fake_fetch_nomad_deployment_plugins_from_info(info_url):
         return {'nomad-parser-plugins-workflow'}
 
-    async def fake_fetch_nomad_deployment_requirements(requirements_url):
+    async def fake_fetch_nomad_deployment_plugins_from_pyproject(pyproject_url):
         return {'nomad-parser-plugins-atomistic'}
 
     monkeypatch.setattr(
@@ -159,14 +159,13 @@ def test_resolve_deployed_plugin_packages_prefers_info_endpoint(monkeypatch):
     monkeypatch.setattr(
         plugin_crawler,
         'fetch_nomad_deployment_plugins_from_pyproject',
-        fake_fetch_nomad_deployment_requirements,
+        fake_fetch_nomad_deployment_plugins_from_pyproject,
     )
 
     resolved = asyncio.run(
         plugin_crawler.resolve_deployed_plugin_packages(
             info_url='https://nomad-lab.eu/prod/v1/api/v1/info',
             pyproject_url='https://gitlab.example/pyproject.toml',
-            legacy_requirements_url='https://gitlab.example/requirements.txt',
         )
     )
     assert resolved == {'nomad-parser-plugins-workflow'}
@@ -194,21 +193,17 @@ def test_resolve_deployed_plugin_packages_falls_back_to_pyproject(monkeypatch):
         plugin_crawler.resolve_deployed_plugin_packages(
             info_url='https://nomad-lab.eu/prod/v1/api/v1/info',
             pyproject_url='https://gitlab.example/pyproject.toml',
-            legacy_requirements_url='https://gitlab.example/requirements.txt',
         )
     )
     assert resolved == {'nomad-parser-plugins-atomistic'}
 
 
-def test_resolve_deployed_plugin_packages_falls_back_to_legacy_requirements(monkeypatch):
+def test_resolve_deployed_plugin_packages_returns_empty_when_both_sources_fail(monkeypatch):
     async def fake_fetch_nomad_deployment_plugins_from_info(info_url):
         return set()
 
     async def fake_fetch_nomad_deployment_plugins_from_pyproject(pyproject_url):
         return set()
-
-    async def fake_fetch_nomad_deployment_requirements(requirements_url):
-        return {'nomad-parser-plugins-workflow'}
 
     monkeypatch.setattr(
         plugin_crawler,
@@ -220,20 +215,14 @@ def test_resolve_deployed_plugin_packages_falls_back_to_legacy_requirements(monk
         'fetch_nomad_deployment_plugins_from_pyproject',
         fake_fetch_nomad_deployment_plugins_from_pyproject,
     )
-    monkeypatch.setattr(
-        plugin_crawler,
-        'fetch_nomad_deployment_requirements',
-        fake_fetch_nomad_deployment_requirements,
-    )
 
     resolved = asyncio.run(
         plugin_crawler.resolve_deployed_plugin_packages(
             info_url='https://nomad-lab.eu/prod/v1/api/v1/info',
             pyproject_url='https://gitlab.example/pyproject.toml',
-            legacy_requirements_url='https://gitlab.example/requirements.txt',
         )
     )
-    assert resolved == {'nomad-parser-plugins-workflow'}
+    assert resolved == set()
 
 
 def test_fetch_nomad_deployment_plugins_from_pyproject(monkeypatch):

--- a/tests/test_plugin_crawler.py
+++ b/tests/test_plugin_crawler.py
@@ -25,6 +25,9 @@ def test_get_plugin_maps_archived_and_owner_type_fields(monkeypatch):
     async def fake_package_exists_on_pypi(package_name):
         return True
 
+    async def fake_check_github_pages_exists(repository_url):
+        return 'https://example.github.io/test-plugin/'
+
     def fake_model_validate(_value):
         return SimpleNamespace(
             stargazers_count=42,
@@ -37,6 +40,9 @@ def test_get_plugin_maps_archived_and_owner_type_fields(monkeypatch):
     monkeypatch.setattr(plugin_crawler, 'get_toml_project', fake_get_toml_project)
     monkeypatch.setattr(
         plugin_crawler, 'package_exists_on_pypi', fake_package_exists_on_pypi
+    )
+    monkeypatch.setattr(
+        plugin_crawler, 'check_github_pages_exists', fake_check_github_pages_exists
     )
     monkeypatch.setattr(
         plugin_crawler.GitHubRepositoryDetailed, 'model_validate', fake_model_validate
@@ -62,6 +68,7 @@ def test_get_plugin_maps_archived_and_owner_type_fields(monkeypatch):
     assert plugin is not None
     assert plugin.archived is True
     assert plugin.owner_type is None
+    assert str(plugin.docs_url) == 'https://example.github.io/test-plugin/'
 
 
 def test_get_plugin_maps_owner_type_organization(monkeypatch):
@@ -85,6 +92,9 @@ def test_get_plugin_maps_owner_type_organization(monkeypatch):
     async def fake_package_exists_on_pypi(package_name):
         return True
 
+    async def fake_check_github_pages_exists(repository_url):
+        return None
+
     def fake_model_validate(_value):
         return SimpleNamespace(
             stargazers_count=42,
@@ -97,6 +107,9 @@ def test_get_plugin_maps_owner_type_organization(monkeypatch):
     monkeypatch.setattr(plugin_crawler, 'get_toml_project', fake_get_toml_project)
     monkeypatch.setattr(
         plugin_crawler, 'package_exists_on_pypi', fake_package_exists_on_pypi
+    )
+    monkeypatch.setattr(
+        plugin_crawler, 'check_github_pages_exists', fake_check_github_pages_exists
     )
     monkeypatch.setattr(
         plugin_crawler.GitHubRepositoryDetailed, 'model_validate', fake_model_validate
@@ -121,3 +134,11 @@ def test_get_plugin_maps_owner_type_organization(monkeypatch):
 
     assert plugin is not None
     assert plugin.owner_type == 'Organization'
+    assert plugin.docs_url is None
+
+
+def test_check_github_pages_exists_non_github_url():
+    docs_url = asyncio.run(
+        plugin_crawler.check_github_pages_exists('https://gitlab.com/example/repo')
+    )
+    assert docs_url is None


### PR DESCRIPTION
- Added archived support end-to-end in plugin data model and crawler extraction -- closes #25 
-  Added owner_type (Organization/User) to the schema and crawler mapping -- closes #26 
-  Added docs_url detection via GitHub Pages (https://<owner>.github.io/<repo>/) and exposed it in output -- closes #23 
- Fixed on_central / on_example_oasis broken fetch. Now use  API-first deployment detection via /api/v1/info, fallback to nomad-distro toml -- closes #22 

- Improved package matching robustness with normalized package-name comparison
- Added crawler-focused unit tests for: archived/owner/docs mapping, API-first vs fallback resolution paths, pyproject plugin parsing
